### PR TITLE
catch HttpRequestException to avoid ObjectDisposedException

### DIFF
--- a/IPX800cs/Commands/Senders/CommandSenderHttp.cs
+++ b/IPX800cs/Commands/Senders/CommandSenderHttp.cs
@@ -27,6 +27,10 @@ internal class CommandSenderHttp : ICommandSender
 			response.EnsureSuccessStatusCode();
 			return ReadResponse(response);
 		}
+		catch (HttpRequestException e)
+		{
+			throw new IPX800SendCommandException(e.Message, e);
+		}
 		catch (Exception e) when (e is not IPX800SendCommandException)
 		{
 			var message = response != null ? ReadResponse(response) : "";


### PR DESCRIPTION
can occurs when trying to access to the response content when an HttpRequestException has been thrown