### PR TITLE
IPX800 v5 parser returns empty list instead of throwing exception when GetOutputs JSON response is empty

### DIFF
--- a/IPX800cs.Test/Parsers/v5/IPX800V5GetAnalogInputsResponseParserTest.cs
+++ b/IPX800cs.Test/Parsers/v5/IPX800V5GetAnalogInputsResponseParserTest.cs
@@ -13,7 +13,6 @@ public class IPX800V5GetAnalogInputsResponseParserTest
     [InlineData("")]
     [InlineData("   ")]
     [InlineData(null)]
-    [InlineData("[]")]
     [InlineData("{}")]
     [InlineData("Some Invalid String")]
     public void GivenInvalidResponse_ParseResponse_ThrowsInvalidResponseException(string invalidResponse)

--- a/IPX800cs.Test/Parsers/v5/IPX800V5GetDelayedOutputsResponseParserTest.cs
+++ b/IPX800cs.Test/Parsers/v5/IPX800V5GetDelayedOutputsResponseParserTest.cs
@@ -13,7 +13,6 @@ public class IPX800V5GetDelayedOutputsResponseParserTest
     [InlineData("")]
     [InlineData("   ")]
     [InlineData(null)]
-    [InlineData("[]")]
     [InlineData("{}")]
     [InlineData("Some Invalid String")]
     public void GivenInvalidResponse_ParseResponse_ThrowsInvalidResponseException(string invalidresponse)

--- a/IPX800cs.Test/Parsers/v5/IPX800V5GetInputsResponseParserTest.cs
+++ b/IPX800cs.Test/Parsers/v5/IPX800V5GetInputsResponseParserTest.cs
@@ -13,7 +13,6 @@ public class IPX800V5GetInputsResponseParserTest
     [InlineData("")]
     [InlineData("   ")]
     [InlineData(null)]
-    [InlineData("[]")]
     [InlineData("{}")]
     [InlineData("Some Invalid String")]
     public void GivenInvalidResponse_ParseResponse_ThrowsInvalidResponseException(string invalidresponse)

--- a/IPX800cs.Test/Parsers/v5/IPX800V5GetOpenCollectorOutputsResponseParserTest.cs
+++ b/IPX800cs.Test/Parsers/v5/IPX800V5GetOpenCollectorOutputsResponseParserTest.cs
@@ -13,7 +13,6 @@ public class IPX800V5GetOpenCollectorOutputsResponseParserTest
     [InlineData("")]
     [InlineData("   ")]
     [InlineData(null)]
-    [InlineData("[]")]
     [InlineData("{}")]
     [InlineData("Some Invalid String")]
     public void GivenInvalidResponse_ParseResponse_ThrowsInvalidResponseException(string invalidresponse)

--- a/IPX800cs.Test/Parsers/v5/IPX800V5GetOptoInputsResponseParserTest.cs
+++ b/IPX800cs.Test/Parsers/v5/IPX800V5GetOptoInputsResponseParserTest.cs
@@ -13,7 +13,6 @@ public class IPX800V5GetOptoInputsResponseParserTest
     [InlineData("")]
     [InlineData("   ")]
     [InlineData(null)]
-    [InlineData("[]")]
     [InlineData("{}")]
     [InlineData("Some Invalid String")]
     public void GivenInvalidResponse_ParseResponse_ThrowsInvalidResponseException(string invalidresponse)

--- a/IPX800cs.Test/Parsers/v5/IPX800V5GetOutputsResponseParserTest.cs
+++ b/IPX800cs.Test/Parsers/v5/IPX800V5GetOutputsResponseParserTest.cs
@@ -13,7 +13,6 @@ public class IPX800V5GetOutputsResponseParserTest
     [InlineData("")]
     [InlineData("   ")]
     [InlineData(null)]
-    [InlineData("[]")]
     [InlineData("{}")]
     [InlineData("Some Invalid String")]
     public void GivenInvalidResponse_ParseResponse_ThrowsInvalidResponseException(string invalidresponse)

--- a/IPX800cs.Test/Parsers/v5/IPX800V5GetTimersResponseParserTest.cs
+++ b/IPX800cs.Test/Parsers/v5/IPX800V5GetTimersResponseParserTest.cs
@@ -12,7 +12,6 @@ public class IPX800V5GetTimersResponseParserTest
     [InlineData("")]
     [InlineData("   ")]
     [InlineData(null)]
-    [InlineData("[]")]
     [InlineData("{}")]
     [InlineData("Some Invalid String")]
     public void GivenInvalidResponse_ParseResponse_ThrowsInvalidResponseException(string invalidResponse)

--- a/IPX800cs.Test/Parsers/v5/IPX800V5GetVirtualInputsResponseParserTest.cs
+++ b/IPX800cs.Test/Parsers/v5/IPX800V5GetVirtualInputsResponseParserTest.cs
@@ -13,7 +13,6 @@ public class IPX800V5GetVirtualInputsResponseParserTest
     [InlineData("")]
     [InlineData("   ")]
     [InlineData(null)]
-    [InlineData("[]")]
     [InlineData("{}")]
     [InlineData("Some Invalid String")]
     public void GivenInvalidResponse_ParseResponse_ThrowsInvalidResponseException(string invalidresponse)

--- a/IPX800cs.Test/Parsers/v5/IPX800V5GetVirtualOutputsResponseParserTest.cs
+++ b/IPX800cs.Test/Parsers/v5/IPX800V5GetVirtualOutputsResponseParserTest.cs
@@ -13,7 +13,6 @@ public class IPX800V5GetVirtualOutputsResponseParserTest
     [InlineData("")]
     [InlineData("   ")]
     [InlineData(null)]
-    [InlineData("[]")]
     [InlineData("{}")]
     [InlineData("Some Invalid String")]
     public void GivenInvalidResponse_ParseResponse_ThrowsInvalidResponseException(string invalidresponse)

--- a/IPX800cs/Parsers/v5/JsonResponseParser.cs
+++ b/IPX800cs/Parsers/v5/JsonResponseParser.cs
@@ -35,13 +35,7 @@ internal static class JsonResponseParser
 
     private static List<T> ParseCollection<T>(string jsonResponse) where T : class
     {
-        var parsedResponse = Parse<List<T>>(jsonResponse);
-        if (parsedResponse.Count == 0)
-        {
-            throw new IPX800InvalidResponseException(jsonResponse);
-        }
-
-        return parsedResponse;
+        return Parse<List<T>>(jsonResponse);
     }
 
     private static T Parse<T>(string jsonResponse) where T : class


### PR DESCRIPTION
+semver: major